### PR TITLE
Demo fixes

### DIFF
--- a/Assets/Scenes/MineLevel.unity
+++ b/Assets/Scenes/MineLevel.unity
@@ -3291,6 +3291,9 @@ GameObject:
   - component: {fileID: 1285284233}
   - component: {fileID: 1285284235}
   - component: {fileID: 1285284234}
+  - component: {fileID: 1285284238}
+  - component: {fileID: 1285284237}
+  - component: {fileID: 1285284236}
   m_Layer: 6
   m_Name: Foreground without beams and ropes
   m_TagString: Untagged
@@ -4062,6 +4065,83 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!251 &1285284236
+PlatformEffector2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285284232}
+  m_Enabled: 1
+  m_UseColliderMask: 1
+  m_ColliderMask:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_RotationalOffset: 0
+  m_UseOneWay: 1
+  m_UseOneWayGrouping: 0
+  m_SurfaceArc: 90
+  m_UseSideFriction: 0
+  m_UseSideBounce: 0
+  m_SideArc: 1
+--- !u!114 &1285284237
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285284232}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 83219e58000aa18459f1fbd9af505f05, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Main::LevelObjects.staticEfects.OneWayPlatform
+--- !u!61 &1285284238
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1285284232}
+  m_Enabled: 1
+  serializedVersion: 3
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IncludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_ExcludeLayers:
+    serializedVersion: 2
+    m_Bits: 0
+  m_LayerOverridePriority: 0
+  m_ForceSendLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ForceReceiveLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_ContactCaptureLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_CallbackLayers:
+    serializedVersion: 2
+    m_Bits: 4294967295
+  m_IsTrigger: 0
+  m_UsedByEffector: 1
+  m_CompositeOperation: 0
+  m_CompositeOrder: 0
+  m_Offset: {x: 7.9053683, y: -4.2477336}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 55.737797, y: 32.550003}
+    newSize: {x: 55.737797, y: 32.550003}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  m_Size: {x: 1.4709597, y: 0.42927647}
+  m_EdgeRadius: 0
 --- !u!4 &1294032284 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2960012822288901877, guid: 4332ef01586141746a2e9fca2ad4cf5e, type: 3}

--- a/Assets/Scenes/MineLevel.unity
+++ b/Assets/Scenes/MineLevel.unity
@@ -462,7 +462,7 @@ BoxCollider2D:
     serializedVersion: 2
     m_Bits: 4294967295
   m_IsTrigger: 0
-  m_UsedByEffector: 0
+  m_UsedByEffector: 1
   m_CompositeOperation: 0
   m_CompositeOrder: 0
   m_Offset: {x: -1.2737274, y: -0.95843434}


### PR DESCRIPTION
This pull request updates the MineLevel scene to add a new one-way platform to the "Foreground without beams and ropes" GameObject. The changes introduce new components and configure collider and effector settings to enable one-way platform behavior.

**One-way platform addition:**

* Added a new `PlatformEffector2D` component to the "Foreground without beams and ropes" GameObject, configured with `m_UseOneWay: 1` and a surface arc of 90 degrees to allow one-way collision.
* Added a new `BoxCollider2D` component and set `m_UsedByEffector: 1` to enable the collider to work with the platform effector. [[1]](diffhunk://#diff-e78b8178ebdac37946c889edd977c0dbb5079994d91eab4f95761a492d2fd4feR3294-R3296) [[2]](diffhunk://#diff-e78b8178ebdac37946c889edd977c0dbb5079994d91eab4f95761a492d2fd4feR4068-R4144)

**Collider configuration updates:**

* Changed the `m_UsedByEffector` property of an existing `BoxCollider2D` from 0 to 1 to enable effector usage for one-way platform functionality.

**Component structure updates:**

* Updated the list of components for the "Foreground without beams and ropes" GameObject to include the new effector, collider, and associated MonoBehaviour for one-way platform logic. [[1]](diffhunk://#diff-e78b8178ebdac37946c889edd977c0dbb5079994d91eab4f95761a492d2fd4feR3294-R3296) [[2]](diffhunk://#diff-e78b8178ebdac37946c889edd977c0dbb5079994d91eab4f95761a492d2fd4feR4068-R4144)