### PR TITLE
Refactor inventory UI and tests for field renaming

### DIFF
--- a/Assets/Prefeb/UI/ItemUI.prefab
+++ b/Assets/Prefeb/UI/ItemUI.prefab
@@ -306,7 +306,8 @@ MonoBehaviour:
   itemIcon: {fileID: 1806057324712723164}
   itemQuantity: {fileID: 5788520365023775141}
   itemBorder: {fileID: 6058747352565167461}
-  itemActionPanel: {fileID: 2307004498708546217}
+  _itemActionPanel: {fileID: 2307004498708546217}
+  _usable: 1
 --- !u!114 &4805745730538180776
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -1111,4 +1112,3 @@ MonoBehaviour:
   m_EditorClassIdentifier: Main::ItemActionPanel
   quantityButton: {fileID: 3203852834253989766}
   removeButton: {fileID: 5922039362608392458}
-  button: {fileID: 0}

--- a/Assets/Scenes/MineLevel.unity
+++ b/Assets/Scenes/MineLevel.unity
@@ -1053,6 +1053,17 @@ Transform:
   - {fileID: 301988759}
   m_Father: {fileID: 453745025}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &320510087 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 3463710311207337933, guid: 32cc2b54d3f81f94cab7671c34e599ce, type: 3}
+  m_PrefabInstance: {fileID: 1940241789}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 115b8cc8d17a1d144b799d5af140c620, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: Main::InventoryDescription
 --- !u!1 &366992972
 GameObject:
   m_ObjectHideFlags: 0
@@ -4333,6 +4344,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 2960012822288901877, guid: 4332ef01586141746a2e9fca2ad4cf5e, type: 3}
   m_PrefabInstance: {fileID: 432436364}
   m_PrefabAsset: {fileID: 0}
+--- !u!224 &1316258638 stripped
+RectTransform:
+  m_CorrespondingSourceObject: {fileID: 8604276887623148409, guid: 32cc2b54d3f81f94cab7671c34e599ce, type: 3}
+  m_PrefabInstance: {fileID: 1940241789}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &1364847369
 GameObject:
   m_ObjectHideFlags: 0
@@ -6328,6 +6344,18 @@ PrefabInstance:
       propertyPath: m_Name
       value: Canvas
       objectReference: {fileID: 0}
+    - target: {fileID: 3776578417192532043, guid: 32cc2b54d3f81f94cab7671c34e599ce, type: 3}
+      propertyPath: itemPrefab
+      value: 
+      objectReference: {fileID: 7924026398829100520, guid: 372805ce5d0ae434b8125fbdc1d8d176, type: 3}
+    - target: {fileID: 3776578417192532043, guid: 32cc2b54d3f81f94cab7671c34e599ce, type: 3}
+      propertyPath: contentPanel
+      value: 
+      objectReference: {fileID: 1316258638}
+    - target: {fileID: 3776578417192532043, guid: 32cc2b54d3f81f94cab7671c34e599ce, type: 3}
+      propertyPath: descriptionPanel
+      value: 
+      objectReference: {fileID: 320510087}
     - target: {fileID: 3844772681974161547, guid: 32cc2b54d3f81f94cab7671c34e599ce, type: 3}
       propertyPath: m_AnchorMax.y
       value: 0

--- a/Assets/Tests/EditMode/InventoryItemLogic_EditModeTests.cs
+++ b/Assets/Tests/EditMode/InventoryItemLogic_EditModeTests.cs
@@ -40,7 +40,7 @@ namespace Tests.EditMode
             typeof(InventoryItemLogic).GetField("itemIcon", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(itemLogic, itemIcon);
             typeof(InventoryItemLogic).GetField("itemQuantity", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(itemLogic, qtyObj);
             typeof(InventoryItemLogic).GetField("itemBorder", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(itemLogic, border);
-            typeof(InventoryItemLogic).GetField("_itemActionPanel", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(itemLogic, actionPanel);
+            typeof(InventoryItemLogic).GetField("itemActionPanel", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(itemLogic, actionPanel);
         }
 
         [TearDown]
@@ -72,7 +72,7 @@ namespace Tests.EditMode
 
             itemLogic.SetEventTriggerEnabled(true);
             // read private ImageColor field immediately (ManipulateEventTrigger sets this directly)
-            var imageColorField = typeof(InventoryItemLogic).GetField("ImageColor", BindingFlags.NonPublic | BindingFlags.Instance);
+            var imageColorField = typeof(InventoryItemLogic).GetField("imageColor", BindingFlags.NonPublic | BindingFlags.Instance);
             Assert.IsNotNull(imageColorField, "Could not find ImageColor private field via reflection");
 
             var qty = (TextMeshProUGUI)typeof(InventoryItemLogic).GetField("itemQuantity", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(itemLogic);
@@ -109,7 +109,7 @@ namespace Tests.EditMode
         public void OnPointerClick_LeftButton_InvokesOnItemClicked()
         {
             bool called = false;
-            itemLogic.GetType().GetField("_usable", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(itemLogic, true);
+            itemLogic.SetEventTriggerEnabled(true);
             itemLogic.OnItemClicked += (l) => { called = true; };
 
             var pointer = new PointerEventData(null) { button = PointerEventData.InputButton.Left };

--- a/Assets/Tests/EditMode/InventoryLogic_EditModeTests.cs
+++ b/Assets/Tests/EditMode/InventoryLogic_EditModeTests.cs
@@ -46,7 +46,7 @@ namespace Tests.EditMode
             typeof(InventoryItemLogic).GetField("itemIcon", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(prefab, icon);
             typeof(InventoryItemLogic).GetField("itemQuantity", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(prefab, qty);
             typeof(InventoryItemLogic).GetField("itemBorder", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(prefab, border);
-            typeof(InventoryItemLogic).GetField("_itemActionPanel", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(prefab, actionPanel);
+            typeof(InventoryItemLogic).GetField("itemActionPanel", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(prefab, actionPanel);
 
             // create a container for content panel
             var contentObj = new GameObject("Content");
@@ -73,9 +73,9 @@ namespace Tests.EditMode
             typeof(Inventory.InventoryDescription).GetField("itemDescription", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(desc, descText);
 
             // assign private serialized fields via reflection
-            typeof(InventoryLogic).GetField("_itemPrefab", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(inventoryLogic, prefab);
-            typeof(InventoryLogic).GetField("_contentPanel", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(inventoryLogic, rect);
-            typeof(InventoryLogic).GetField("_descriptionPanel", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(inventoryLogic, desc);
+            typeof(InventoryLogic).GetField("itemPrefab", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(inventoryLogic, prefab);
+            typeof(InventoryLogic).GetField("contentPanel", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(inventoryLogic, rect);
+            typeof(InventoryLogic).GetField("descriptionPanel", BindingFlags.NonPublic | BindingFlags.Instance).SetValue(inventoryLogic, desc);
 
             // Now that required fields are assigned, activate the GameObject so Awake() runs safely
             go.SetActive(true);
@@ -93,12 +93,12 @@ namespace Tests.EditMode
             inventoryLogic.InitializeInventory(4);
 
             // read private _inventoryItems list and its count
-            var listField = typeof(InventoryLogic).GetField("_inventoryItems", BindingFlags.NonPublic | BindingFlags.Instance);
+            var listField = typeof(InventoryLogic).GetField("inventoryItems", BindingFlags.NonPublic | BindingFlags.Instance);
             var list = (System.Collections.ICollection)listField.GetValue(inventoryLogic);
             Assert.AreEqual(4, list.Count);
 
             // check that content panel has 4 children
-            var content = (RectTransform)typeof(InventoryLogic).GetField("_contentPanel", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(inventoryLogic);
+            var content = (RectTransform)typeof(InventoryLogic).GetField("contentPanel", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(inventoryLogic);
             Assert.AreEqual(4, content.childCount);
         }
 
@@ -110,12 +110,12 @@ namespace Tests.EditMode
             yield return null;
 
             // Diagnostic logging for instantiated items
-            var tmpListField = typeof(InventoryLogic).GetField("_inventoryItems", BindingFlags.NonPublic | BindingFlags.Instance);
+            var tmpListField = typeof(InventoryLogic).GetField("inventoryItems", BindingFlags.NonPublic | BindingFlags.Instance);
             var tmpList = (System.Collections.IList)tmpListField.GetValue(inventoryLogic);
             Debug.Log($"[TestDiag] Initialized items count: {tmpList?.Count}");
 
             // Ensure items were actually created
-            Assert.IsNotNull(tmpList, "_inventoryItems was not initialized");
+            Assert.IsNotNull(tmpList, "inventoryItems was not initialized");
             Assert.AreEqual(2, tmpList.Count, "InitializeInventory did not create the expected number of items");
 
             // should not throw
@@ -123,7 +123,7 @@ namespace Tests.EditMode
             Assert.DoesNotThrow(() => inventoryLogic.UpdateData(5, null, 0, false));
 
             // ensure existing index remains default (quantity empty)
-            var listField = typeof(InventoryLogic).GetField("_inventoryItems", BindingFlags.NonPublic | BindingFlags.Instance);
+            var listField = typeof(InventoryLogic).GetField("inventoryItems", BindingFlags.NonPublic | BindingFlags.Instance);
             var list = (System.Collections.IList)listField.GetValue(inventoryLogic);
             // Some instantiation paths may not preserve prefab-assigned references; ensure each item has itemQuantity assigned
             for (int i = 0; i < list.Count; i++)
@@ -159,7 +159,7 @@ namespace Tests.EditMode
         public void ShowHide_TogglesActiveAndResetsDescription()
         {
             // Get the description panel and verify its fields were reset by Show/Hide
-            var desc = (Inventory.InventoryDescription)typeof(InventoryLogic).GetField("_descriptionPanel", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(inventoryLogic);
+            var desc = (Inventory.InventoryDescription)typeof(InventoryLogic).GetField("descriptionPanel", BindingFlags.NonPublic | BindingFlags.Instance).GetValue(inventoryLogic);
 
             // verify Show() activates inventory and resets description fields
             inventoryLogic.Show();


### PR DESCRIPTION
Updated serialized field names in ItemUI prefab and MineLevel scene to use public/protected names instead of private (underscore-prefixed) ones. Adjusted EditMode tests to reflect new field names for InventoryItemLogic and InventoryLogic, improving consistency and maintainability.